### PR TITLE
Check for stale oracle data

### DIFF
--- a/Chainlink/GetEthPrice.sol
+++ b/Chainlink/GetEthPrice.sol
@@ -21,13 +21,20 @@ contract PriceConsumerV3 {
      */
     function getLatestPrice() public view returns (int) {
         (
-            /*uint80 roundID*/,
-            int price,
-            /*uint startedAt*/,
-            /*uint timeStamp*/,
-            /*uint80 answeredInRound*/
+        uint80 roundID,
+        int price,
+        /*uint startedAt*/,
+        uint timeStamp,
+        uint80 answeredInRound
         ) = priceFeed.latestRoundData();
+        require(
+            timeStamp != 0,
+            "PriceConsumerV3::getLatestAnswer: round is not complete"
+        );
+        require(
+            answeredInRound >= roundID,
+            "PriceConsumerV3::getLatestAnswer: stale data"
+        );
         return price;
-    
     }
 }


### PR DESCRIPTION
There were no checks if the return value indicates stale data. This could lead to stale prices according to the Chainlink documentation: “if answeredInRound < roundId could indicate stale data.” “A timestamp with zero value means the round is not complete and should not be used.”